### PR TITLE
Cambio en el ReadMe, de GKBA a GKBA Reproyectado

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Visualización de la cantidad de habitantes por comuna de la Ciudad Autónoma de
 #### Comando para pasar el shapefile de las comunas a KML (usando GDAL):
 ```
 ogr2ogr 
-	-s_srs "+proj=tmerc +lat_0=-34.629717 +lon_0=-58.462700 +x_0=100000 +y_0=100000 +k=0.999998 +units=m +ellps=intl +a=6378388 +rf=297 +no_defs" 
+	-s_srs "+proj=tmerc +lat_0=-34.629269 +lon_0=-58.463300 +x_0=100000 +y_0=100000 +k=0.999998 +units=m +ellps=intl +a=6378388 +rf=297 +no_defs" 
 	-t_srs "EPSG:4326" 
 	-f "KML" 
 	Comunas.kml Comunas.shp
@@ -27,7 +27,7 @@ ogr2ogr
 #### Comando para pasar el shapefile de las comunas a GeoJSON (usando GDAL):
 ```
 ogr2ogr 
-	-s_srs "+proj=tmerc +lat_0=-34.629717 +lon_0=-58.462700 +x_0=100000 +y_0=100000 +k=0.999998 +units=m +ellps=intl +a=6378388 +rf=297 +no_defs" 
+	-s_srs "+proj=tmerc +lat_0=-34.629269 +lon_0=-58.463300 +x_0=100000 +y_0=100000 +k=0.999998 +units=m +ellps=intl +a=6378388 +rf=297 +no_defs" 
 	-t_srs "EPSG:4326" 
 	-f "GeoJSON" 
 	Comunas.json Comunas.shp


### PR DESCRIPTION
Chicos, ojo con esto. _Por lo menos_ en la API de mapas, están devolviendo todo con la referencia de GKBA Reroyectado (http://spatialreference.org/ref/sr-org/7433/) y no con la de GKBA. No se si en el archivo de comunas estará igual, aunque es probable que no hayan notado mas que un leve corrimiento.

Hope it helps :)
